### PR TITLE
Fix typo: 'eldrich' to 'eldritch'.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -111,7 +111,7 @@
             <h4 class="faq-item">How does it work?</h4>
             <div class="faq-item">
                 <p class="muted outro">
-                    Due to rapid advancement in dark ritual technology, the programming community has streamlined the development and deployment of unspeakable eldrich horrors. Using robust open-source libraries like a sack of live geese, websites like this one can be developed with far more efficient sacrificial rituals than ever before. We're still stuck on the version with really inefficient sacrifical rituals though, due to comp͆aͭatib̊i̼͕l̈̿i̮̜t̚y̅ ͊i͋s̾s̢͈͠u̶e̛̊s̼̃.
+                    Due to rapid advancement in dark ritual technology, the programming community has streamlined the development and deployment of unspeakable eldritch horrors. Using robust open-source libraries like a sack of live geese, websites like this one can be developed with far more efficient sacrificial rituals than ever before. We're still stuck on the version with really inefficient sacrifical rituals though, due to comp͆aͭatib̊i̼͕l̈̿i̮̜t̚y̅ ͊i͋s̾s̢͈͠u̶e̛̊s̼̃.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
“Eldrich” is not wrong per se, but “eldritch” seems to be a more common spelling.